### PR TITLE
Refactor config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ local_log = []
 members = [
     "rd-interface",
     "rd-std",
+    "rd-derive",
 ]
 
 [profile.release]

--- a/rd-derive/Cargo.toml
+++ b/rd-derive/Cargo.toml
@@ -3,6 +3,8 @@ name = "rd-derive"
 version = "0.1.0"
 authors = ["spacemeowx2 <spacemeowx2@gmail.com>"]
 edition = "2018"
+description = "Derive for easier create rabbit-digger config."
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rd-derive/Cargo.toml
+++ b/rd-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rd-derive"
+version = "0.1.0"
+authors = ["spacemeowx2 <spacemeowx2@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"
+
+[lib]
+proc-macro = true

--- a/rd-derive/src/lib.rs
+++ b/rd-derive/src/lib.rs
@@ -1,0 +1,38 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+#[proc_macro_derive(Config)]
+pub fn config(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    // eprintln!("Test {:#?}", input);
+    let ident = input.ident;
+    let mut resolve_body = quote! {};
+
+    let fields = match input.data {
+        Data::Struct(s) => s.fields,
+        _ => panic!("Config must be Struct"),
+    };
+
+    for field in fields {
+        let field_name = field.ident.unwrap();
+        let line = quote! {
+            rd_interface::registry::ResolveNetRef::resolve(&mut self.#field_name, nets)?;
+        };
+        resolve_body.extend(line);
+    }
+
+    let expanded = quote! {
+        impl rd_interface::registry::ResolveNetRef for #ident {
+            fn resolve(&mut self, nets: &rd_interface::registry::NetMap) -> rd_interface::Result<()> {
+                #resolve_body
+                Ok(())
+            }
+        }
+    };
+
+    // eprintln!("Test {}", expanded.to_string());
+
+    TokenStream::from(expanded)
+}

--- a/rd-derive/src/lib.rs
+++ b/rd-derive/src/lib.rs
@@ -6,7 +6,6 @@ use syn::{parse_macro_input, Data, DeriveInput};
 pub fn config(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    // eprintln!("Test {:#?}", input);
     let ident = input.ident;
     let mut resolve_body = quote! {};
 
@@ -31,8 +30,6 @@ pub fn config(input: TokenStream) -> TokenStream {
             }
         }
     };
-
-    // eprintln!("Test {}", expanded.to_string());
 
     TokenStream::from(expanded)
 }

--- a/rd-interface/Cargo.toml
+++ b/rd-interface/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = { version = "1.0", features = [ "std", "preserve_order" ] }
 serde = "1.0"
 serde_derive = "1.0"
 tokio = { version = "1.5", features = ["io-util"] }
+rd-derive = { version = "0.1", path = "../rd-derive" }

--- a/rd-interface/src/error.rs
+++ b/rd-interface/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     AbortedByUser,
     #[error("Context error: {0:?}")]
     Context(#[from] crate::context::Error),
+    #[error("Not found")]
+    NotFound(String),
     #[error("{0:?}")]
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/rd-interface/src/lib.rs
+++ b/rd-interface/src/lib.rs
@@ -2,6 +2,7 @@ pub use address::{Address, IntoAddress};
 pub use context::Context;
 pub use error::{Error, Result, NOT_IMPLEMENTED};
 pub use interface::*;
+pub use rd_derive::Config;
 pub use registry::Registry;
 pub use serde_json::Value;
 pub use util::{CombineNet, NotImplementedNet};

--- a/rd-interface/src/registry.rs
+++ b/rd-interface/src/registry.rs
@@ -1,17 +1,17 @@
 use std::{collections::HashMap, fmt};
 
+pub use self::net_ref::{NetRef, ResolveNetRef};
 use crate::{INet, IServer, IntoDyn, Net, Result, Server};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-pub type FromConfig<T> = Box<dyn Fn(Vec<Net>, Value) -> Result<T>>;
+pub type NetMap = HashMap<String, Net>;
 
-#[derive(Debug, Default, serde_derive::Deserialize)]
-pub struct EmptyConfig(Value);
+mod net_ref;
 
 pub struct Registry {
-    pub net: HashMap<String, FromConfig<Net>>,
-    pub server: HashMap<String, FromConfig<Server>>,
+    pub net: HashMap<String, NetResolver>,
+    pub server: HashMap<String, ServerResolver>,
 }
 
 impl fmt::Debug for Registry {
@@ -31,26 +31,52 @@ impl Registry {
         }
     }
     pub fn add_net<N: NetFactory>(&mut self) {
-        self.net.insert(N::NAME.into(), N::into_dyn());
+        self.net.insert(N::NAME.into(), NetResolver::new::<N>());
     }
     pub fn add_server<S: ServerFactory>(&mut self) {
-        self.server.insert(S::NAME.into(), S::into_dyn());
+        self.server
+            .insert(S::NAME.into(), ServerResolver::new::<S>());
     }
 }
 
 pub trait NetFactory {
     const NAME: &'static str;
-    type Config: DeserializeOwned;
+    type Config: DeserializeOwned + ResolveNetRef;
     type Net: INet + Sized + 'static;
 
-    fn new(nets: Vec<Net>, config: Self::Config) -> Result<Self::Net>;
-    fn into_dyn() -> FromConfig<Net> {
-        Box::new(move |nets, cfg| {
-            serde_json::from_value(cfg)
-                .map_err(Into::<crate::Error>::into)
-                .and_then(|cfg| Self::new(nets, cfg))
-                .map(|n| n.into_dyn())
-        })
+    fn new(config: Self::Config) -> Result<Self::Net>;
+}
+
+pub struct NetResolver {
+    build: fn(nets: &NetMap, cfg: Value) -> Result<Net>,
+    get_dependency: fn(cfg: Value) -> Result<Vec<String>>,
+}
+
+impl NetResolver {
+    fn new<N: NetFactory>() -> Self {
+        Self {
+            build: |nets, cfg| {
+                serde_json::from_value(cfg)
+                    .map_err(Into::<crate::Error>::into)
+                    .and_then(|mut cfg: N::Config| {
+                        cfg.resolve(nets)?;
+                        Ok(cfg)
+                    })
+                    .and_then(|cfg| N::new(cfg))
+                    .map(|n| n.into_dyn())
+            },
+            get_dependency: |cfg| {
+                serde_json::from_value(cfg)
+                    .map_err(Into::<crate::Error>::into)
+                    .and_then(|mut cfg: N::Config| cfg.get_dependency())
+            },
+        }
+    }
+    pub fn build(&self, nets: &NetMap, cfg: Value) -> Result<Net> {
+        (self.build)(nets, cfg)
+    }
+    pub fn get_dependency(&self, cfg: Value) -> Result<Vec<String>> {
+        (self.get_dependency)(cfg)
     }
 }
 
@@ -59,23 +85,34 @@ pub trait ServerFactory {
     type Config: DeserializeOwned;
     type Server: IServer + Sized + 'static;
 
-    fn new(listen_net: Net, net: Net, config: Self::Config) -> Result<Self::Server>;
-    fn into_dyn() -> FromConfig<Server> {
-        Box::new(move |mut nets, cfg| {
-            serde_json::from_value(cfg)
-                .map_err(Into::<crate::Error>::into)
-                .and_then(|cfg| {
-                    if nets.len() != 2 {
-                        return Err(crate::Error::Other(
-                            "Server must have listen_net and net".to_string().into(),
-                        ));
-                    }
-                    let listen_net = nets.remove(0);
-                    let net = nets.remove(0);
+    fn new(listen: Net, net: Net, config: Self::Config) -> Result<Self::Server>;
+}
 
-                    Self::new(listen_net, net, cfg)
-                })
-                .map(|n| n.into_dyn())
-        })
+pub struct ServerResolver {
+    build: fn(listen_net: Net, net: Net, cfg: Value) -> Result<Server>,
+}
+
+impl ServerResolver {
+    fn new<N: ServerFactory>() -> Self {
+        Self {
+            build: |listen_net, net: Net, cfg| {
+                serde_json::from_value(cfg)
+                    .map_err(Into::<crate::Error>::into)
+                    .and_then(|cfg| N::new(listen_net, net, cfg))
+                    .map(|n| n.into_dyn())
+            },
+        }
+    }
+    pub fn build(&self, listen_net: Net, net: Net, cfg: Value) -> Result<Server> {
+        (self.build)(listen_net, net, cfg)
+    }
+}
+
+#[derive(Debug, Default, serde_derive::Deserialize)]
+pub struct EmptyConfig(Value);
+
+impl ResolveNetRef for EmptyConfig {
+    fn resolve(&mut self, _nets: &NetMap) -> Result<()> {
+        Ok(())
     }
 }

--- a/rd-interface/src/registry/net_ref.rs
+++ b/rd-interface/src/registry/net_ref.rs
@@ -1,0 +1,119 @@
+use super::NetMap;
+use crate::{Error, Net, NotImplementedNet, Result};
+use serde::de;
+use std::{fmt, ops::Deref, sync::Arc};
+
+#[derive(Clone)]
+pub struct NetRef {
+    name: String,
+    net: Option<Net>,
+}
+
+impl Default for NetRef {
+    fn default() -> Self {
+        default_net()
+    }
+}
+
+impl fmt::Debug for NetRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("NetRef").field(&self.name).finish()
+    }
+}
+
+fn default_net() -> NetRef {
+    NetRef {
+        name: "local".to_string(),
+        net: None,
+    }
+}
+
+impl NetRef {
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+    pub fn net(&self) -> Net {
+        self.net
+            .as_ref()
+            .expect("Net must be resolved before used")
+            .clone()
+    }
+}
+
+impl Deref for NetRef {
+    type Target = Net;
+
+    fn deref(&self) -> &Self::Target {
+        self.net
+            .as_ref()
+            .expect("Net must be resolved before Deref")
+    }
+}
+
+impl<'de> de::Deserialize<'de> for NetRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct FieldVisitor;
+        impl<'de> de::Visitor<'de> for FieldVisitor {
+            type Value = NetRef;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "Net name string")
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(NetRef { name: v, net: None })
+            }
+        }
+
+        deserializer.deserialize_string(FieldVisitor)
+    }
+}
+
+pub trait ResolveNetRef {
+    fn resolve(&mut self, _nets: &NetMap) -> Result<()> {
+        Ok(())
+    }
+    fn get_dependency(&mut self) -> Result<Vec<String>> {
+        let noop = Arc::new(NotImplementedNet);
+        let mut tmp_map = NetMap::new();
+        loop {
+            match self.resolve(&tmp_map) {
+                Ok(_) => break,
+                Err(Error::NotFound(key)) => {
+                    tmp_map.insert(key, noop.clone());
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(tmp_map.into_iter().map(|i| i.0).collect())
+    }
+}
+
+impl ResolveNetRef for NetRef {
+    fn resolve(&mut self, nets: &NetMap) -> Result<()> {
+        let net = nets
+            .get(&self.name)
+            .ok_or_else(|| crate::Error::NotFound(self.name.clone()))?
+            .clone();
+        self.net = Some(net);
+        Ok(())
+    }
+}
+
+macro_rules! impl_empty_resolve {
+    ($($x:ident),+ $(,)?) => ($(
+        impl ResolveNetRef for $x {
+            fn resolve(&mut self, _nets: &NetMap) -> Result<()> {
+                Ok(())
+            }
+        }
+    )*)
+}
+
+impl_empty_resolve! { String, u16 }

--- a/rd-interface/src/util.rs
+++ b/rd-interface/src/util.rs
@@ -177,14 +177,6 @@ impl INet for CombineNet {
     }
 }
 
-pub fn get_one_net(mut nets: Vec<Net>) -> Result<Net> {
-    if nets.len() != 1 {
-        return Err(crate::Error::Other("Must have one net".to_string().into()));
-    }
-
-    Ok(nets.remove(0))
-}
-
 pub async fn connect_udp(udp_channel: UdpChannel, udp: UdpSocket) -> crate::Result<()> {
     let in_side = async {
         let mut buf = [0u8; crate::constant::UDP_BUFFER_SIZE];

--- a/rd-std/Cargo.toml
+++ b/rd-std/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # common
 rd-interface = { version = "0.4", path = "../rd-interface" }
+rd-derive = { version = "0.1", path = "../rd-derive" }
 futures = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
@@ -18,7 +19,7 @@ anyhow = "1.0"
 tokio = { version = "1.5.0", features = ["net", "rt"] }
 
 # socks5
-socks5-protocol = "0.3.0"
+socks5-protocol = "0.3.2"
 
 # http
 http = { version = "0.2.4", optional = true }

--- a/rd-std/src/builtin/alias.rs
+++ b/rd-std/src/builtin/alias.rs
@@ -1,9 +1,9 @@
 use futures::future::BoxFuture;
 use rd_interface::{
-    registry::{EmptyConfig, NetFactory},
-    util::get_one_net,
-    Address, Context, INet, Result, TcpListener, TcpStream, UdpSocket,
+    registry::{NetFactory, NetRef},
+    Address, Config, Context, INet, Result, TcpListener, TcpStream, UdpSocket,
 };
+use serde_derive::Deserialize;
 
 pub struct AliasNet(rd_interface::Net);
 
@@ -51,12 +51,17 @@ impl INet for AliasNet {
     }
 }
 
+#[derive(Debug, Deserialize, Config)]
+pub struct Config {
+    net: NetRef,
+}
+
 impl NetFactory for AliasNet {
     const NAME: &'static str = "alias";
-    type Config = EmptyConfig;
+    type Config = Config;
     type Net = Self;
 
-    fn new(nets: Vec<rd_interface::Net>, _config: Self::Config) -> Result<Self> {
-        Ok(AliasNet::new(get_one_net(nets)?))
+    fn new(config: Self::Config) -> Result<Self> {
+        Ok(AliasNet::new(config.net.net()))
     }
 }

--- a/rd-std/src/builtin/forward.rs
+++ b/rd-std/src/builtin/forward.rs
@@ -11,6 +11,7 @@ pub struct ForwardConfig {
     bind: String,
     target: String,
 }
+
 pub struct ForwardNet {
     listen_net: Net,
     net: Net,
@@ -72,7 +73,7 @@ impl ServerFactory for ForwardNet {
     type Config = ForwardConfig;
     type Server = Self;
 
-    fn new(listen_net: Net, net: Net, config: Self::Config) -> Result<Self> {
-        Ok(ForwardNet::new(listen_net, net, config))
+    fn new(listen: Net, net: Net, cfg: Self::Config) -> Result<Self> {
+        Ok(ForwardNet::new(listen, net, cfg))
     }
 }

--- a/rd-std/src/builtin/local.rs
+++ b/rd-std/src/builtin/local.rs
@@ -112,7 +112,7 @@ impl NetFactory for LocalNet {
     type Config = EmptyConfig;
     type Net = Self;
 
-    fn new(_nets: Vec<rd_interface::Net>, _config: Self::Config) -> Result<Self> {
+    fn new(_config: Self::Config) -> Result<Self> {
         Ok(LocalNet::new())
     }
 }

--- a/rd-std/src/builtin/noop.rs
+++ b/rd-std/src/builtin/noop.rs
@@ -10,7 +10,7 @@ impl NetFactory for NoopNet {
     type Config = EmptyConfig;
     type Net = NotImplementedNet;
 
-    fn new(_nets: Vec<rd_interface::Net>, _config: Self::Config) -> Result<Self::Net> {
+    fn new(_config: Self::Config) -> Result<Self::Net> {
         Ok(NotImplementedNet)
     }
 }

--- a/rd-std/src/redir.rs
+++ b/rd-std/src/redir.rs
@@ -71,7 +71,7 @@ mod linux {
         type Config = RedirServerConfig;
         type Server = Self;
 
-        fn new(_listen_net: Net, net: Net, config: Self::Config) -> Result<Self> {
+        fn new(_: Net, net: Net, config: Self::Config) -> Result<Self> {
             Ok(RedirServer::new(config, net))
         }
     }

--- a/src/config/default.rs
+++ b/src/config/default.rs
@@ -1,13 +1,5 @@
 use std::path::PathBuf;
 
-pub fn local_chain() -> Vec<String> {
-    vec!["local".to_string()]
-}
-
-pub fn noop_chain() -> Vec<String> {
-    vec!["noop".to_string()]
-}
-
 pub fn local_string() -> String {
     "local".to_string()
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -66,9 +66,9 @@ impl INet for ControllerNet {
     }
 }
 
-async fn process(mut rx: mpsc::UnboundedReceiver<Event>, inner: Arc<RwLock<Inner>>) {
+async fn process(mut rx: mpsc::UnboundedReceiver<Event>, _inner: Arc<RwLock<Inner>>) {
     loop {
-        let e = match rx.recv().now_or_never() {
+        let _e = match rx.recv().now_or_never() {
             Some(Some(e)) => e,
             Some(None) => break,
             None => {
@@ -77,11 +77,13 @@ async fn process(mut rx: mpsc::UnboundedReceiver<Event>, inner: Arc<RwLock<Inner
             }
         };
 
-        let mut inner = inner.write().await;
-        inner.events.push_back(e);
-        while let Some(Some(e)) = rx.recv().now_or_never() {
-            inner.events.push_back(e);
-        }
+        // log::trace!("{:?}", e);
+
+        // let mut inner = inner.write().await;
+        // inner.events.push_back(e);
+        // while let Some(Some(e)) = rx.recv().now_or_never() {
+        //     inner.events.push_back(e);
+        // }
     }
 }
 

--- a/src/rabbit_digger.rs
+++ b/src/rabbit_digger.rs
@@ -131,6 +131,8 @@ async fn start_server(server: Server) -> Result<()> {
 
 struct ServerInfo {
     name: String,
+    listen: String,
+    net: String,
     server: Server,
     config: Value,
 }
@@ -139,7 +141,11 @@ struct ServerList<'a>(&'a Vec<ServerInfo>);
 
 impl fmt::Display for ServerInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.name, self.config)
+        write!(
+            f,
+            "{}: {} -> {} {}",
+            self.name, self.listen, self.net, self.config
+        )
     }
 }
 
@@ -263,6 +269,8 @@ fn init_server(
                 name: name.to_string(),
                 server,
                 config: i.opt,
+                listen: i.listen,
+                net: i.net,
             });
             Ok(())
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,16 +2,19 @@ use std::{collections::HashMap, hash::Hash};
 
 use topological_sort::TopologicalSort;
 
-pub fn topological_sort<K, V, D>(mut map: HashMap<K, V>, get_deps: D) -> Option<Vec<(K, V)>>
+pub fn topological_sort<K, V, D, E>(
+    mut map: HashMap<K, V>,
+    get_deps: D,
+) -> Result<Option<Vec<(K, V)>>, E>
 where
     K: Hash + Eq + Clone,
-    D: Fn(&V) -> Vec<&K>,
+    D: Fn(&V) -> Result<Vec<K>, E>,
 {
-    let mut ts = TopologicalSort::<&K>::new();
+    let mut ts = TopologicalSort::<K>::new();
 
     for (k, v) in map.iter() {
-        for d in get_deps(v).into_iter() {
-            ts.add_dependency(d, k);
+        for d in get_deps(v)?.into_iter() {
+            ts.add_dependency(d, k.clone());
         }
     }
 
@@ -21,10 +24,10 @@ where
     }
 
     if ts.len() > 0 {
-        return None;
+        return Ok(None);
     }
 
-    Some(
+    Ok(Some(
         list.into_iter()
             .map(|k| {
                 let v = map.remove(&k);
@@ -32,5 +35,5 @@ where
             })
             .filter_map(|i| i)
             .collect(),
-    )
+    ))
 }


### PR DESCRIPTION
`chain` is removed in config struct. Net implementer should use `NetRef` instead. By deriving with `Config`, the struct could be resolved by rabbit-digger. 